### PR TITLE
Disable no-useless-escape rule

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -49,7 +49,7 @@ module.exports = {
         "no-extra-bind": 2,
         "no-sequences": 2,
         "no-useless-call": 2,
-        "no-useless-escape": 2,
+        "no-useless-escape": 0,
         "no-useless-return": 2,
         "no-with": 2,
         "wrap-iife": [2, "inside"],


### PR DESCRIPTION
Rule does not perform well with dynamic regex strings
![image](https://cloud.githubusercontent.com/assets/516342/22832034/247f2176-efb5-11e6-8850-9f872e0a5bf1.png)

1st:
```javascript
ext = '\w*{2,4}'
...
new RegExp(`^https:${ASSETS_DOMAIN}.*${ext}$`)
```

2nd:
```javascript
.replace(/(-[\w]{20,}$)|(\.min)|([\.-]\d)/g, '') // clean name
```