### PR TITLE
no-unused-vars: ignoreRestSiblings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiverr/eslint-config-fiverr",
   "moduleName": "eslint-config-fiverr",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Fiverr's ESLint config",
   "author": "Fiverr",
   "license": "MIT",

--- a/rules/base.js
+++ b/rules/base.js
@@ -23,6 +23,10 @@ module.exports = {
         "no-multiple-empty-lines": 2,
         "no-trailing-spaces": 1,
         "no-unneeded-ternary": 2,
+        "no-unused-vars": [2, {
+            "varsIgnorePattern": "React",
+            "ignoreRestSiblings": false
+        }],
         "no-whitespace-before-property": 2,
         "quotes": ["error", "single", {"avoidEscape": true}],
         "semi-spacing": 2,


### PR DESCRIPTION
https://eslint.org/docs/rules/no-unused-vars#ignorerestsiblings

Allows extraction by using rest params, without adding a linting error.

Basically, this allows us to use `...rest` params and spread them as props, after extracting everything we don't need.

So:
![image](https://user-images.githubusercontent.com/11255103/29747972-1b97e11a-8b14-11e7-8035-4b15b781c355.png)
![image](https://user-images.githubusercontent.com/11255103/29747974-20889c14-8b14-11e7-88e3-ac4dca4bff1e.png)

will turn into:
![image](https://user-images.githubusercontent.com/11255103/29747976-336efd64-8b14-11e7-90fa-d7a86fe30386.png)

Allowing us to actually spread `...rest` as props on a jsx element without throwing an error for non-existent html prop such as `validate`.

![image](https://user-images.githubusercontent.com/11255103/29747982-5daa59c0-8b14-11e7-86ec-db686324e053.png)


Also adding ignore pattern: "React", to allow us to explicitly import "React" (needs to be in scope for jsx), but actually used by transpiled code, not seen by eslint.