### PR TITLE
no-unused-prop-types: skipShapeProps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiverr/eslint-config-fiverr",
   "moduleName": "eslint-config-fiverr",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Fiverr's ESLint config",
   "author": "Fiverr",
   "license": "MIT",

--- a/rules/react.js
+++ b/rules/react.js
@@ -43,7 +43,9 @@ module.exports = {
         "react/jsx-no-duplicate-props": 2,
         "react/jsx-no-undef": 2,
         "react/jsx-pascal-case": 2,
-        "react/jsx-space-before-closing": [2, "never"],
+        "react/jsx-tag-spacing": [2, {
+            "beforeSelfClosing": "never"
+        }],
         "react/jsx-uses-vars": 2,
         "react/jsx-wrap-multilines": 2
     }

--- a/rules/react.js
+++ b/rules/react.js
@@ -20,7 +20,10 @@ module.exports = {
         "react/no-string-refs": 2,
         "react/no-unescaped-entities": 2,
         "react/no-unknown-property": 2,
-        "react/no-unused-prop-types": 2,
+        "react/no-unused-prop-types": [2, {
+            "customValidators": [],
+            "skipShapeProps": true
+        }],
         "react/prefer-es6-class": 2,
         "react/prefer-stateless-function": 2,
         "react/sort-comp": 2,


### PR DESCRIPTION
1) Adds the skipShapeProps flag to no-unused-prop-types rule. This fixes a false positive and avoids having to add intermediate variables for code like this:

![image](https://user-images.githubusercontent.com/3209660/30885221-001600d0-a2d8-11e7-9952-0d1570a5c352.png)

which'll otherwise error out in eslint@4.0:

![image](https://user-images.githubusercontent.com/3209660/30885154-dbecf538-a2d7-11e7-84c1-7a71940ae281.png)

2) Removes the deprecated `jsx-space-before-closing` rule and replaces it with `jsx-tag-spacing`.