### PR TITLE
Move react recommendations to react module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@fiverr/eslint-config-fiverr",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiverr/eslint-config-fiverr",
   "moduleName": "eslint-config-fiverr",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Fiverr's ESLint config",
   "author": "Fiverr",
   "license": "MIT",

--- a/rules/base.js
+++ b/rules/base.js
@@ -1,7 +1,6 @@
 module.exports = {
     extends: [
-        'eslint:recommended',
-        'plugin:react/recommended'
+        'eslint:recommended'
     ],
     env: {
         browser: true,

--- a/rules/react.js
+++ b/rules/react.js
@@ -1,4 +1,7 @@
 module.exports = {
+    extends: [
+        'plugin:react/recommended'
+    ],
     plugins: [
         'react'
     ],


### PR DESCRIPTION
So non React repositories will not have to install "eslint-plugin-react", and still consume the other two:
```json
  "extends": [
    "@fiverr/eslint-config-fiverr/rules/base.js",
    "@fiverr/eslint-config-fiverr/rules/es6.js"
  ],
```