### PR TITLE
Allow module mutation in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiverr/eslint-config-fiverr",
   "moduleName": "eslint-config-fiverr",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Fiverr's ESLint config",
   "author": "Fiverr",
   "license": "MIT",

--- a/rules/jest.js
+++ b/rules/jest.js
@@ -1,3 +1,5 @@
+const { IGNORE } = require('../constants');
+
 module.exports = {
     overrides: [
         {
@@ -15,7 +17,8 @@ module.exports = {
                 shallow: false,
             },
             rules: {
-                'no-empty-function': 0
+                'no-empty-function': IGNORE,
+                'import/namespace': IGNORE
             }
         }
     ]

--- a/rules/mocha.js
+++ b/rules/mocha.js
@@ -1,3 +1,5 @@
+const { IGNORE } = require('../constants');
+
 module.exports = {
     overrides: [
         {
@@ -14,7 +16,8 @@ module.exports = {
                 assert: true
             },
             rules: {
-                'no-empty-function': 0
+                'no-empty-function': IGNORE,
+                'import/namespace': IGNORE
             }
         }
     ]


### PR DESCRIPTION
[namespace](https://github.com/benmosher/eslint-plugin-import/blob/HEAD/docs/rules/namespace.md) rule does not allow modifying or extending imported modules.
While desired in prod, it is a feature commonly used in tests.

Example
```js
import * as dependency from './dependency';

describe('..', () => {
	beforeAll(() => {
		dependency.someMethod = stub(); // lint error
	});
});
```