### PR TITLE
Ignore import/no-named-as-default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiverr/eslint-config-fiverr",
   "moduleName": "eslint-config-fiverr",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Fiverr's ESLint config",
   "author": "Fiverr",
   "license": "MIT",

--- a/rules/base.js
+++ b/rules/base.js
@@ -83,6 +83,7 @@ module.exports = {
         'import/no-dynamic-require': IGNORE,
         'import/no-useless-path-segments': ERROR,
         'import/order': WARN,
-        'import/newline-after-import': ERROR
+        'import/newline-after-import': ERROR,
+        'import/no-named-as-default': IGNORE
     }
 };


### PR DESCRIPTION
This rule is a bit annoying and it requires us to create different names when importing wrapper components.