### PR TITLE
[petty]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiverr/eslint-config-fiverr",
   "moduleName": "eslint-config-fiverr",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Fiverr's ESLint config",
   "author": "Fiverr",
   "license": "MIT",

--- a/rules/base.js
+++ b/rules/base.js
@@ -24,6 +24,7 @@ module.exports = {
         'comma-style': ERROR,
         'computed-property-spacing': ERROR,
         'dot-notation': ERROR,
+        'eol-last': ERROR,
         'func-call-spacing': ERROR,
         'indent': [ERROR, 4, {
             SwitchCase: WARN
@@ -38,8 +39,12 @@ module.exports = {
         'new-cap': IGNORE,
         'no-lonely-if': ERROR,
         'no-case-declarations': IGNORE,
-        'no-multiple-empty-lines': ERROR,
-        'no-trailing-spaces': WARN,
+        'no-multiple-empty-lines': [ERROR, {
+            max: 1,
+            maxBOF: 0,
+            maxEOF: 0
+        }],
+        'no-trailing-spaces': ERROR,
         'no-unneeded-ternary': ERROR,
         'no-unused-vars': [ERROR, {
             varsIgnorePattern: 'React',


### PR DESCRIPTION
Don't be petty, be vigilant
<img width="650" src="https://user-images.githubusercontent.com/516342/94829586-5876c300-0413-11eb-9d6b-97182fb7a448.png">

Here are all the error messages:
<img width="487" src="https://user-images.githubusercontent.com/516342/94844488-faec7180-0426-11eb-9cf8-f896eca0692c.png">
<img width="644" src="https://user-images.githubusercontent.com/516342/94844495-fd4ecb80-0426-11eb-82d1-9df85b6fd224.png">
<img width="681" src="https://user-images.githubusercontent.com/516342/94844502-ffb12580-0426-11eb-9d49-4436546ab10c.png">
<img width="496" src="https://user-images.githubusercontent.com/516342/94844505-0344ac80-0427-11eb-9d91-3eb409f60c52.png">

If you're wondering how EOF: 0 is valid - it's because it does not include the "\n" at the end of the line which appears to our editors (and GitHub GUI) as a new, blank line. Instead, the rule "eol-last" enforces the last line ends with the '\n' (new line) character