### PR TITLE
enforce use of catch() on un-returned promises

### DIFF
--- a/fixtures/promise-catch-or-return/fail.js
+++ b/fixtures/promise-catch-or-return/fail.js
@@ -1,0 +1,5 @@
+import { promise } from '.';
+
+export function fails(boolean) {
+    promise(boolean).then(console.log);
+}

--- a/fixtures/promise-catch-or-return/index.js
+++ b/fixtures/promise-catch-or-return/index.js
@@ -1,0 +1,5 @@
+export const promise = (boolean) => new Promise(
+    (resolve, reject) => boolean
+        ? resolve('Okay')
+        : reject(new Error('Something must have gone horribly wrong'))
+);

--- a/fixtures/promise-catch-or-return/pass.js
+++ b/fixtures/promise-catch-or-return/pass.js
@@ -1,0 +1,5 @@
+import { promise } from '.';
+
+export function passes(boolean) {
+    return promise(boolean).then(console.log);
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiverr/eslint-config-fiverr",
   "moduleName": "eslint-config-fiverr",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Fiverr's ESLint config",
   "author": "Fiverr",
   "license": "MIT",
@@ -23,7 +23,8 @@
     "eslint-plugin-react-hooks": "^1.5.1"
   },
   "dependencies": {
-    "eslint-plugin-import": "^2.18.2"
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-promise": "^4.2.1"
   },
   "devDependencies": {
     "async-execute": "^1.2.0",

--- a/rules/base.js
+++ b/rules/base.js
@@ -6,6 +6,9 @@ module.exports = {
         'plugin:import/errors',
         'plugin:import/warnings'
     ],
+    plugins: [
+        'promise'
+    ],
     env: {
         browser: true,
         jquery: true,
@@ -90,6 +93,7 @@ module.exports = {
         'import/no-useless-path-segments': ERROR,
         'import/order': WARN,
         'import/newline-after-import': ERROR,
-        'import/no-named-as-default': IGNORE
+        'import/no-named-as-default': IGNORE,
+        'promise/catch-or-return': ERROR
     }
 };


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| New feature?         | ✔︎
| Tests added?         | ✔︎

Use [eslint-plugin-promise](https://www.npmjs.com/package/eslint-plugin-promise) to enforce use of catch() on un-returned promises.