### PR TITLE
Allow consumers to use eslint gt 5.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiverr/eslint-config-fiverr",
   "moduleName": "eslint-config-fiverr",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Fiverr's ESLint config",
   "author": "Fiverr",
   "license": "MIT",
@@ -18,7 +18,7 @@
     "lint": "eslint '*.js' '**/*.js' --ignore-pattern '**/fail.js'"
   },
   "peerDependencies": {
-    "eslint": "^5.8.0",
+    "eslint": "*",
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-react-hooks": "^1.5.1"
   },


### PR DESCRIPTION
Modify peer dependency so consumers can upgrade beyond 5
![](https://user-images.githubusercontent.com/516342/103753241-72780100-5013-11eb-9be2-b630654af47f.png)
