### PR TITLE
loose peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiverr/eslint-config-fiverr",
   "moduleName": "eslint-config-fiverr",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Fiverr's ESLint config",
   "author": "Fiverr",
   "license": "MIT",
@@ -17,14 +17,16 @@
     "test": "jest",
     "lint": "eslint '*.js' '**/*.js' --ignore-pattern '**/fail.js'"
   },
-  "peerDependencies": {
-    "eslint": "*",
-    "eslint-plugin-react": "^7.11.1",
-    "eslint-plugin-react-hooks": "^1.5.1"
-  },
   "dependencies": {
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-promise": "^4.2.1"
+  },
+  "peerDependencies": {
+    "eslint": "*"
+  },
+  "optionalDependencies": {
+    "eslint-plugin-react": "*",
+    "eslint-plugin-react-hooks": "*"
   },
   "devDependencies": {
     "async-execute": "^1.2.0",


### PR DESCRIPTION
Starting with NPM 7 peer dependencies are being installed.

The peer dependencies in this project have not been updated. As a result "eslint-plugin-react-hooks" had peer dep set up to ^1 (while dev dep was on ^4).

I've changed React dependencies to be **optional** and to **have no version requirement**.

![](https://user-images.githubusercontent.com/516342/103915304-b5b99900-5113-11eb-919d-5adb24fc061c.png)
