### PR TITLE
dynamic-import-chunkname

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiverr/eslint-config-fiverr",
   "moduleName": "eslint-config-fiverr",
-  "version": "3.2.5-rc",
+  "version": "3.2.5",
   "description": "Fiverr's ESLint config",
   "author": "Fiverr",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiverr/eslint-config-fiverr",
   "moduleName": "eslint-config-fiverr",
-  "version": "3.2.4",
+  "version": "3.2.5-rc",
   "description": "Fiverr's ESLint config",
   "author": "Fiverr",
   "license": "MIT",

--- a/rules/base.js
+++ b/rules/base.js
@@ -87,6 +87,7 @@ module.exports = {
         'no-with': ERROR,
         'wrap-iife': [ERROR, 'inside'],
         'consistent-this': ERROR,
+        'import/dynamic-import-chunkname': ERROR,
         'import/no-self-import': ERROR,
         'import/no-internal-modules': IGNORE,
         'import/no-dynamic-require': IGNORE,
@@ -94,7 +95,6 @@ module.exports = {
         'import/order': WARN,
         'import/newline-after-import': ERROR,
         'import/no-named-as-default': IGNORE,
-        'promise/catch-or-return': ERROR,
-        'dynamic-import-chunkname': ERROR
+        'promise/catch-or-return': ERROR
     }
 };

--- a/rules/base.js
+++ b/rules/base.js
@@ -94,6 +94,7 @@ module.exports = {
         'import/order': WARN,
         'import/newline-after-import': ERROR,
         'import/no-named-as-default': IGNORE,
-        'promise/catch-or-return': ERROR
+        'promise/catch-or-return': ERROR,
+        'dynamic-import-chunkname': ERROR
     }
 };


### PR DESCRIPTION
<!-- Please fill out the following form (leave what's relevant) -->

| Q                    | A
| -------------------- | ---
| Bug fix?             | ✘
| New feature?         | ✘
| Breaking change?     | ✘
| Deprecations?        | ✘
| Tests added?         | ✘
| Documentation added? | ✘
| Fixed issues         | <!-- comma-separated list of issues fixed by the pull request, where applicable -->

<!-- Describe your changes below in detail. -->
Adding this rule:
https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/dynamic-import-chunkname.md

This should allow us to catch mistakes like this (notice that the chunk name was forgotten):
https://github.com/fiverr/gig_page_perseus/commit/af751edfa44f2326c25d7028a7bbf6160978b5b7#diff-51e49be8a3f6c52c8eab7dc6d640b5e866cd7381c244471a293c70bf32da2595L14

We will now receive the following linting error:

![image](https://user-images.githubusercontent.com/62507549/116874784-8bd83500-ac22-11eb-9137-7e7478797d2e.png)

