### PR TITLE
Allow unused variable underscore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 3.2.6
+## Improvement
+Also allow unused variable underscore (`_`) and numbered underscores (`_1`, `_2`)

--- a/fixtures/no-unused-vars-react/fail.js
+++ b/fixtures/no-unused-vars-react/fail.js
@@ -1,4 +1,4 @@
 import react from 'react';
-import react_dom from 'react-dom';
+import reactdom from 'react-dom';
 
 export default () => null;

--- a/fixtures/no-unused-vars-react/fail.js
+++ b/fixtures/no-unused-vars-react/fail.js
@@ -1,0 +1,4 @@
+import react from 'react';
+import react_dom from 'react-dom';
+
+export default () => null;

--- a/fixtures/no-unused-vars-react/pass.js
+++ b/fixtures/no-unused-vars-react/pass.js
@@ -1,0 +1,4 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export default () => null;

--- a/fixtures/no-unused-vars/fail.js
+++ b/fixtures/no-unused-vars/fail.js
@@ -1,0 +1,5 @@
+const array = [ 'unneeded', 'unneeded, too', 'needed' ];
+
+const [ unneeded, unneeded_too, needed ] = array;
+
+export default needed;

--- a/fixtures/no-unused-vars/fail.js
+++ b/fixtures/no-unused-vars/fail.js
@@ -1,5 +1,5 @@
 const array = [ 'unneeded', 'unneeded, too', 'needed' ];
 
-const [ unneeded, unneeded_too, needed ] = array;
+const [ unneeded, unneededToo, needed ] = array;
 
 export default needed;

--- a/fixtures/no-unused-vars/pass.js
+++ b/fixtures/no-unused-vars/pass.js
@@ -1,0 +1,5 @@
+const array = [ 'unneeded', 'needed' ];
+
+const [ _, _1, needed ] = array;
+
+export default needed;

--- a/fixtures/no-unused-vars/pass.js
+++ b/fixtures/no-unused-vars/pass.js
@@ -1,4 +1,4 @@
-const array = [ 'unneeded', 'needed' ];
+const array = [ 'unneeded', 'unneeded, too', 'needed' ];
 
 const [ _, _1, needed ] = array;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiverr/eslint-config-fiverr",
   "moduleName": "eslint-config-fiverr",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "Fiverr's ESLint config",
   "author": "Fiverr",
   "license": "MIT",
@@ -34,6 +34,8 @@
     "eslint-plugin-log": "^1.2.3",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^3.0.0",
-    "jest": "^25.2.4"
+    "jest": "^25.2.4",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   }
 }

--- a/rules/base.js
+++ b/rules/base.js
@@ -50,7 +50,7 @@ module.exports = {
         'no-trailing-spaces': ERROR,
         'no-unneeded-ternary': ERROR,
         'no-unused-vars': [ERROR, {
-            varsIgnorePattern: 'React',
+            varsIgnorePattern: '^(_\\d?|React(DOM)?)$',
             ignoreRestSiblings: true
         }],
         'no-whitespace-before-property': ERROR,


### PR DESCRIPTION
That's useful for array destruction. This will potentially allow up to 11 unused variables (`_`, `_0`, `_1` etc) which I think should cover most cases.

Usage example:

```js
const [ [ _, arg2 ] ] = fn.mock.calls;
```

Added tests for React backwards compatibility