### PR TITLE
@fiverr-private/** should come after other externals

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Set npmrc credentials
+          command: echo -e $NPMRC > ~/.npmrc
+      - run:
           name: Install dependencies
           command: npm i
       - run:
@@ -18,9 +21,6 @@ jobs:
       - run:
           name: Lint code
           command: npm run lint -- --plugin log
-      - run:
-          name: Set npmrc credentials
-          command: echo -e $NPMRC > ~/.npmrc
       - run:
           name: Publish this thing
           command: npx published  --git-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# CHANGELOG
+
+## 3.2.6
+
+- Throw on import order
+- @fiverr-private/** should come after all other externals
+
+## 3.2.5
+
+- add dynamic-import-chunkname rule
+
+## 3.2.4
+
+- Change some peer dependencies to optional peer dependencies
+
+## 3.2.3
+
+- Allow any eslint version
+
+## 3.2.2
+
+- enforce use of catch() on un-returned promises
+
+## 3.2.1
+
+- Update empty line rules
+
+## 3.2.0
+
+- Space in object curly brackets

--- a/fixtures/import-order-fiverr/fail.js
+++ b/fixtures/import-order-fiverr/fail.js
@@ -1,0 +1,4 @@
+import { stats } from '@fiverr-private/obs';
+import { snakeCase } from 'lodash';
+
+stats.gauge([ 'function', snakeCase(snakeCase.name) ].join('.'), 1);

--- a/fixtures/import-order-fiverr/pass.js
+++ b/fixtures/import-order-fiverr/pass.js
@@ -1,0 +1,4 @@
+import { snakeCase } from 'lodash';
+import { stats } from '@fiverr-private/obs';
+
+stats.gauge([ 'function', snakeCase(snakeCase.name) ].join('.'), 1);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiverr/eslint-config-fiverr",
   "moduleName": "eslint-config-fiverr",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "Fiverr's ESLint config",
   "author": "Fiverr",
   "license": "MIT",
@@ -29,12 +29,14 @@
     "eslint-plugin-react-hooks": "*"
   },
   "devDependencies": {
+    "@fiverr-private/obs": "^1.28.1",
     "async-execute": "^1.2.0",
     "eslint": "^6.8.0",
     "eslint-plugin-log": "^1.2.3",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^3.0.0",
     "jest": "^25.2.4",
+    "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   }

--- a/rules/base.js
+++ b/rules/base.js
@@ -92,7 +92,16 @@ module.exports = {
         'import/no-internal-modules': IGNORE,
         'import/no-dynamic-require': IGNORE,
         'import/no-useless-path-segments': ERROR,
-        'import/order': WARN,
+        'import/order': [ ERROR, {
+            'pathGroups': [
+                {
+                    'pattern': '@fiverr-private/**',
+                    'group': 'external',
+                    'position': 'after'
+                }
+            ],
+            pathGroupsExcludedImportTypes: ['builtin']
+        }],
         'import/newline-after-import': ERROR,
         'import/no-named-as-default': IGNORE,
         'promise/catch-or-return': ERROR


### PR DESCRIPTION
- import rules would now throw errors instead of warnings.
- @fiverr-private should come at the end of external imports